### PR TITLE
VB-2241: Add LogoURL to CompetitorRate model

### DIFF
--- a/api/competitor_rates_test.go
+++ b/api/competitor_rates_test.go
@@ -19,6 +19,7 @@ func TestGetCompetitorsRates(t *testing.T) {
 		{
 			Provider:     "remitly",
 			ProviderName: "Remitly",
+			LogoURL:      "https://vban-resources.s3.us-east-2.amazonaws.com/logos/remitly.png",
 			From:         "USD",
 			To:           "NGN",
 			Rate:         1500.25,
@@ -26,6 +27,7 @@ func TestGetCompetitorsRates(t *testing.T) {
 		{
 			Provider:     "nala",
 			ProviderName: "Nala",
+			LogoURL:      "https://vban-resources.s3.us-east-2.amazonaws.com/logos/nala.png",
 			From:         "USD",
 			To:           "NGN",
 			Rate:         1498.5,

--- a/model/competitor_rate.go
+++ b/model/competitor_rate.go
@@ -4,6 +4,7 @@ package model
 type CompetitorRate struct {
 	Provider     string  `json:"provider"`
 	ProviderName string  `json:"provider_name"`
+	LogoURL      string  `json:"logo_url"`
 	From         string  `json:"from"`
 	To           string  `json:"to"`
 	Rate         float64 `json:"rate"`


### PR DESCRIPTION
## Summary
- Adds `LogoURL string \`json:\"logo_url\"\`` to `model.CompetitorRate` so consumers can render competitor logos alongside rates.
- Updates the existing `TestGetCompetitorsRates` fixture to include the new field, asserting it round-trips correctly.

